### PR TITLE
Proposal for how utils should be written and developer usage

### DIFF
--- a/src/services/__mocks__/memcached-elasticache.js
+++ b/src/services/__mocks__/memcached-elasticache.js
@@ -1,20 +1,34 @@
 const Memcached = jest.fn().mockImplementation((url, options) => {
+  let mockedCache = null;
+
   return {
-    set: jest.fn().mockImplementation((cacheKey, cacheData, cacheTime) => {
-      return {
-        mocked: {
-          cacheKey,
-          cacheData,
-          cacheTime,
-        },
-      };
+    set: jest
+      .fn()
+      .mockImplementation((cacheKey, cacheData, cacheTime, callback) => {
+        if (cacheKey === 'mockError') return callback('mockedError');
+        if (cacheKey === 'mockException') throw new Error('mockedException');
+
+        mockedCache = {
+          [cacheKey]: {
+            data: cacheData,
+            lifetime: cacheTime,
+          },
+        };
+
+        return callback(null, true);
+      }),
+    get: jest.fn().mockImplementation((cacheKey, callback) => {
+      if (cacheKey === 'mockError') return callback('mockedError');
+      if (cacheKey === 'mockException') throw new Error('mockedException');
+
+      return callback(null, mockedCache[cacheKey]);
     }),
-    get: jest.fn().mockImplementation(cacheKey => {
-      return {
-        mocked: {
-          cacheKey,
-        },
-      };
+    del: jest.fn().mockImplementation((cacheKey, callback) => {
+      if (cacheKey === 'mockError') return callback('mockedError');
+      if (cacheKey === 'mockException') throw new Error('mockedException');
+
+      mockedCache = { [cacheKey]: true };
+      return callback(null, mockedCache[cacheKey]);
     }),
     mocked: {
       url,

--- a/src/utils/__tests__/cache.spec.js
+++ b/src/utils/__tests__/cache.spec.js
@@ -61,18 +61,27 @@ describe('UtilsGroup: test cache utils', () => {
       cache.set('mockException', cacheData, cacheTime)
     ).rejects.toMatchObject({
       code: 'CACHE_SET_EXCEPTION',
+      message: 'mockedException',
+      name: 'LesgoException',
+      statusCode: 500,
     });
   });
 
   it('test getting cache with exception', async () => {
     await expect(cache.get('mockException')).rejects.toMatchObject({
       code: 'CACHE_GET_EXCEPTION',
+      message: 'mockedException',
+      name: 'LesgoException',
+      statusCode: 500,
     });
   });
 
   it('test deleting cache with exception', async () => {
     await expect(cache.del('mockException')).rejects.toMatchObject({
       code: 'CACHE_DEL_EXCEPTION',
+      message: 'mockedException',
+      name: 'LesgoException',
+      statusCode: 500,
     });
   });
 });

--- a/src/utils/__tests__/cache.spec.js
+++ b/src/utils/__tests__/cache.spec.js
@@ -1,35 +1,78 @@
 import cache from '../cache';
 
 describe('UtilsGroup: test cache utils', () => {
-  it('test setting cache', () => {
-    const cacheKey = 'data';
-    const cacheData = {
-      someData: [
-        {
-          someDataKey1: 'someDataValue1',
-        },
-        {
-          someDataKey2: 'someDataValue2',
-        },
-      ],
-    };
-
-    expect(cache().set(cacheKey, cacheData, 10)).toMatchObject({
-      mocked: {
-        cacheKey,
-        cacheData,
-        cacheTime: 10,
+  const cacheKey = 'cacheKey';
+  const cacheTime = 10;
+  const cacheData = {
+    someData: [
+      {
+        someDataKey1: 'someDataValue1',
       },
+      {
+        someDataKey2: 'someDataValue2',
+      },
+    ],
+  };
+
+  it('test cache utils', async () => {
+    await expect(cache.set(cacheKey, cacheData, cacheTime)).resolves.toEqual(
+      true
+    );
+
+    await expect(cache.get(cacheKey)).resolves.toMatchObject({
+      data: cacheData,
+      lifetime: cacheTime,
+    });
+
+    await expect(cache.del(cacheKey)).resolves.toEqual(true);
+  });
+
+  it('test setting cache with error', async () => {
+    await expect(
+      cache.set('mockError', cacheData, cacheTime)
+    ).rejects.toMatchObject({
+      code: 'CACHE_SET_ERROR',
+      message: 'mockedError',
+      name: 'LesgoException',
+      statusCode: 500,
     });
   });
 
-  it('test getting cache', () => {
-    const cacheKey = 'data';
+  it('test getting cache with error', async () => {
+    await expect(cache.get('mockError')).rejects.toMatchObject({
+      code: 'CACHE_GET_ERROR',
+      message: 'mockedError',
+      name: 'LesgoException',
+      statusCode: 500,
+    });
+  });
 
-    expect(cache().get(cacheKey)).toMatchObject({
-      mocked: {
-        cacheKey,
-      },
+  it('test deleting cache with error', async () => {
+    await expect(cache.del('mockError')).rejects.toMatchObject({
+      code: 'CACHE_DEL_ERROR',
+      message: 'mockedError',
+      name: 'LesgoException',
+      statusCode: 500,
+    });
+  });
+
+  it('test setting cache with exception', async () => {
+    await expect(
+      cache.set('mockException', cacheData, cacheTime)
+    ).rejects.toMatchObject({
+      code: 'CACHE_SET_EXCEPTION',
+    });
+  });
+
+  it('test getting cache with exception', async () => {
+    await expect(cache.get('mockException')).rejects.toMatchObject({
+      code: 'CACHE_GET_EXCEPTION',
+    });
+  });
+
+  it('test deleting cache with exception', async () => {
+    await expect(cache.del('mockException')).rejects.toMatchObject({
+      code: 'CACHE_DEL_EXCEPTION',
     });
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -33,7 +33,7 @@ const ec = (conn = null) => {
 const get = key => {
   return new Promise((res, rej) => {
     try {
-      ec.get(key, (err, data) => {
+      ec().get(key, (err, data) => {
         if (err) {
           rej(new LesgoException(err, 'CACHE_GET_ERROR'));
         } else {
@@ -44,7 +44,7 @@ const get = key => {
       rej(new LesgoException(err, 'CACHE_GET_EXCEPTION'));
     }
 
-    ec.end();
+    ec().end();
   });
 };
 
@@ -59,7 +59,7 @@ const get = key => {
 const set = (key, val, lifetime) => {
   return new Promise((res, rej) => {
     try {
-      ec.set(key, val, lifetime, err => {
+      ec().set(key, val, lifetime, err => {
         if (err) {
           rej(new LesgoException(err, 'CACHE_SET_ERROR'));
         } else {
@@ -70,7 +70,7 @@ const set = (key, val, lifetime) => {
       rej(new LesgoException(err, 'CACHE_SET_EXCEPTION'));
     }
 
-    ec.end();
+    ec().end();
   });
 };
 
@@ -83,7 +83,7 @@ const set = (key, val, lifetime) => {
 const del = key => {
   return new Promise((res, rej) => {
     try {
-      ec.del(key, err => {
+      ec().del(key, err => {
         if (err) {
           rej(new LesgoException(err, 'CACHE_DEL_ERROR'));
         } else {
@@ -94,9 +94,13 @@ const del = key => {
       rej(new LesgoException(err, 'CACHE_DEL_EXCEPTION'));
     }
 
-    ec.end();
+    ec().end();
   });
 };
 
-export { get, set, del };
-export default ec;
+export default {
+  ec,
+  get,
+  set,
+  del,
+};

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,8 +1,15 @@
 import config from 'Config/cache'; // eslint-disable-line import/no-unresolved
 import ElastiCacheService from '../services/ElastiCacheService';
+import LesgoException from '../exceptions/LesgoException';
 
 const singleton = [];
 
+/**
+ * Instantiate the Cache Service
+ *
+ * @param {object} conn The connection options
+ * @return {object} Returns the driver
+ */
 const ec = (conn = null) => {
   if (singleton[conn]) {
     return singleton[conn];
@@ -17,4 +24,79 @@ const ec = (conn = null) => {
   return driver;
 };
 
+/**
+ * Fetch data from cache by key
+ *
+ * @param {string} key Cache key to fetch data.
+ * @return {promise} Returns promised.
+ */
+const get = key => {
+  return new Promise((res, rej) => {
+    try {
+      ec.get(key, (err, data) => {
+        if (err) {
+          rej(new LesgoException(err, 'CACHE_GET_ERROR'));
+        } else {
+          res(data);
+        }
+      });
+    } catch (err) {
+      rej(new LesgoException(err, 'CACHE_GET_EXCEPTION'));
+    }
+
+    ec.end();
+  });
+};
+
+/**
+ * Save data to cache
+ *
+ * @param {string} key Cache key to save data.
+ * @param {string|object} val Value of data to cache.
+ * @param {integer} lifetime Time in seconds to expire cache.
+ * @return {promise} Returns promised.
+ */
+const set = (key, val, lifetime) => {
+  return new Promise((res, rej) => {
+    try {
+      ec.set(key, val, lifetime, err => {
+        if (err) {
+          rej(new LesgoException(err, 'CACHE_SET_ERROR'));
+        } else {
+          res(true);
+        }
+      });
+    } catch (err) {
+      rej(new LesgoException(err, 'CACHE_SET_EXCEPTION'));
+    }
+
+    ec.end();
+  });
+};
+
+/**
+ * Remove the key from cache
+ *
+ * @param {string} key Cache key to delete.
+ * @return {promise} Returns promised.
+ */
+const del = key => {
+  return new Promise((res, rej) => {
+    try {
+      ec.del(key, err => {
+        if (err) {
+          rej(new LesgoException(err, 'CACHE_DEL_ERROR'));
+        } else {
+          res(true);
+        }
+      });
+    } catch (err) {
+      rej(new LesgoException(err, 'CACHE_DEL_EXCEPTION'));
+    }
+
+    ec.end();
+  });
+};
+
+export { get, set, del };
 export default ec;

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -2,6 +2,9 @@ import config from 'Config/cache'; // eslint-disable-line import/no-unresolved
 import ElastiCacheService from '../services/ElastiCacheService';
 import LesgoException from '../exceptions/LesgoException';
 
+/**
+ * Reusable instance
+ */
 const singleton = [];
 
 /**
@@ -41,7 +44,7 @@ const get = key => {
         }
       });
     } catch (err) {
-      rej(new LesgoException(err, 'CACHE_GET_EXCEPTION'));
+      rej(new LesgoException(err.message, 'CACHE_GET_EXCEPTION', 500, err));
     }
 
     ec().end();
@@ -67,7 +70,7 @@ const set = (key, val, lifetime) => {
         }
       });
     } catch (err) {
-      rej(new LesgoException(err, 'CACHE_SET_EXCEPTION'));
+      rej(new LesgoException(err.message, 'CACHE_SET_EXCEPTION', 500, err));
     }
 
     ec().end();
@@ -91,7 +94,7 @@ const del = key => {
         }
       });
     } catch (err) {
-      rej(new LesgoException(err, 'CACHE_DEL_EXCEPTION'));
+      rej(new LesgoException(err.message, 'CACHE_DEL_EXCEPTION', 500, err));
     }
 
     ec().end();


### PR DESCRIPTION
Proposing for how util functions should be written with a proper DocBloc and de-structuring concept. This is how the utils should be utilized

```js
import cache from 'Utils/cache';
const cachedData = await cache.get('cacheKey');
```

OR

```js
import { get } from 'Utils/cache';
const cachedData = await get('cacheKey');
```

VS existing

```js
import cache from 'Utils/cache';
cache().get('cacheKey', (err, data) => {
  console.log(`Logger: err(${err}) data(${data})`);
});
cache().end();
```