### PR TITLE
Add referesh option to es index

### DIFF
--- a/src/services/ElasticsearchService.js
+++ b/src/services/ElasticsearchService.js
@@ -132,12 +132,13 @@ class ElasticsearchService {
     });
   }
 
-  indexOrCreateById(body) {
+  indexOrCreateById(body, refresh = false) {
     const params = {
       index: this.index,
       type: this.type,
       id: body.id,
       body,
+      refresh,
     };
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This is to allow refresh ES after indexing is done. 

When creating code coverage, i noticed that ES does not update documents in an instance, therefore search result are still showing old document. After reading ES documentation, there is refresh option. This would refresh the search as soon as new index is updated.

Documentation can be found here. https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
