### PR TITLE
Add support for alb and remove CORS headers

### DIFF
--- a/src/middlewares/__tests__/errorHttpResponseMiddleware.spec.js
+++ b/src/middlewares/__tests__/errorHttpResponseMiddleware.spec.js
@@ -10,7 +10,6 @@ describe('MiddlewareGroup: test errorHandler middleware', () => {
       error: new Error('Test validation error'),
     });
 
-    expect(data.headers['Access-Control-Allow-Credentials']).toBe(true);
     expect(data.headers['Access-Control-Allow-Origin']).toBe('*');
     expect(data.headers['Cache-Control']).toBe('no-cache');
 
@@ -114,7 +113,6 @@ describe('MiddlewareGroup: test errorHandler middleware', () => {
   it('test with undefined opts', () => {
     const data = errorHttpResponseHandler();
 
-    expect(data.headers['Access-Control-Allow-Credentials']).toBe(true);
     expect(data.headers['Access-Control-Allow-Origin']).toBe('*');
     expect(data.headers['Cache-Control']).toBe('no-cache');
 

--- a/src/middlewares/__tests__/normalizeHttpRequestMiddleware.spec.js
+++ b/src/middlewares/__tests__/normalizeHttpRequestMiddleware.spec.js
@@ -9,6 +9,11 @@ describe('MiddlewareGroup: test normalizeRequest', () => {
     expect(data).toBe(null);
   });
 
+  it('test with empty parameters from alb', () => {
+    const data = normalizeRequest({ headers: null, qs: {}, body: null });
+    expect(data).toBe(null);
+  });
+
   it('test with empty header parameters', () => {
     const data = normalizeRequest({ headers: {}, qs: null, body: null });
     expect(data).toBe(null);

--- a/src/middlewares/__tests__/successHttpResponseMiddleware.spec.js
+++ b/src/middlewares/__tests__/successHttpResponseMiddleware.spec.js
@@ -7,7 +7,6 @@ describe('MiddlewareGroup: test successHttpResponseHandler middleware', () => {
   it('test default without parameters', () => {
     const data = successHttpResponseHandler();
 
-    expect(data.headers['Access-Control-Allow-Credentials']).toBe(true);
     expect(data.headers['Access-Control-Allow-Origin']).toBe('*');
     expect(data.headers['Cache-Control']).toBe('no-cache');
 
@@ -24,7 +23,6 @@ describe('MiddlewareGroup: test successHttpResponseHandler middleware', () => {
   it('test default', () => {
     const data = successHttpResponseHandler({ response: 'Some message' });
 
-    expect(data.headers['Access-Control-Allow-Credentials']).toBe(true);
     expect(data.headers['Access-Control-Allow-Origin']).toBe('*');
     expect(data.headers['Cache-Control']).toBe('no-cache');
 

--- a/src/middlewares/errorHttpResponseMiddleware.js
+++ b/src/middlewares/errorHttpResponseMiddleware.js
@@ -7,7 +7,6 @@ export const errorHttpResponseHandler = opts => {
     event: {},
     debugMode: false,
     headers: {
-      'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'no-cache',
     },

--- a/src/middlewares/normalizeHttpRequestMiddleware.js
+++ b/src/middlewares/normalizeHttpRequestMiddleware.js
@@ -1,8 +1,12 @@
 import logger from '../utils/logger';
 
 export const normalizeRequest = opts => {
-  const { headers, qs, body } = opts;
+  const { headers, body } = opts;
+  let { qs } = opts;
   let input = null;
+
+  // to be consistent with api gateway, we convert empty object to null
+  if (JSON.stringify(qs) === '{}') qs = null;
 
   if (!headers && qs === null) return input;
 

--- a/src/middlewares/successHttpResponseMiddleware.js
+++ b/src/middlewares/successHttpResponseMiddleware.js
@@ -5,7 +5,6 @@ export const successHttpResponseHandler = opts => {
     event: {},
     debugMode: false,
     headers: {
-      'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'no-cache',
     },


### PR DESCRIPTION
Since empty querystringParameter from ALB is defaulted to {} while API Gateway is null. We need to normalize it to be the same.

Remove Access-Control-Allow-Origin from default header because:
1. Only required for CORS request.
2. API gateway will return 503 Error when headers has Access-Control-Allow-Credentials.

However Access-Control-Allow-Origin is still can be added through httpMiddleware options.