### PR TITLE
Add tags support for API Gateway v2

### DIFF
--- a/src/middlewares/__tests__/normalizeHttpRequestMiddleware.spec.js
+++ b/src/middlewares/__tests__/normalizeHttpRequestMiddleware.spec.js
@@ -1,7 +1,9 @@
+import app from 'Config/app'; // eslint-disable-line import/no-unresolved
 import {
   normalizeRequest,
   normalizeHttpRequestBeforeHandler,
 } from '../normalizeHttpRequestMiddleware';
+import logger from '../../utils/logger';
 
 describe('MiddlewareGroup: test normalizeRequest', () => {
   it('test with default parameters', () => {
@@ -100,7 +102,6 @@ describe('MiddlewareGroup: test normalizeHttpRequestBeforeHandler', () => {
     };
 
     normalizeHttpRequestBeforeHandler(handler, () => {});
-    expect(handler.event.requestContext.requestId).toBe('requestId');
   });
 
   it('should return auth.sub if Authorization exists', () => {
@@ -115,5 +116,67 @@ describe('MiddlewareGroup: test normalizeHttpRequestBeforeHandler', () => {
 
     normalizeHttpRequestBeforeHandler(handler, () => {});
     expect(handler.event.auth.sub).toBe('f2b5349d-f5e3-44f5-9c08-ae6b01e95434');
+  });
+
+  it.each`
+    version  | tags
+    ${'1.0'} | ${{ path: '/v1/path', httpMethod: 'GET' }}
+    ${'2.0'} | ${{ path: '/v2/path', httpMethod: 'POST' }}
+    ${'3.0'} | ${{ path: '/v2/path', httpMethod: 'POST' }}
+  `(
+    'should identify path and httpMethod based on version',
+    ({ version, tags }) => {
+      const handler = {
+        event: {
+          version,
+          headers: {},
+          path: '/v1/path',
+          httpMethod: 'GET',
+          requestContext: {
+            http: {
+              path: '/v2/path',
+              method: 'POST',
+            },
+          },
+        },
+      };
+      normalizeHttpRequestBeforeHandler(handler, () => {});
+      expect(logger.meta.tags).toStrictEqual(tags);
+    }
+  );
+
+  it('should not set tags when using API Gateway v2 and requestContext is empty', () => {
+    const handler = {
+      event: {
+        version: '2.0',
+        headers: {},
+      },
+    };
+
+    normalizeHttpRequestBeforeHandler(handler, () => {});
+    expect(logger.meta.tags).toStrictEqual({});
+  });
+
+  it('should not set meta on debug', () => {
+    app.debug = true;
+    const handler = {
+      event: {
+        headers: {},
+        auth: '1',
+        queryStringParameters: {
+          foo: 'bar',
+        },
+        body: {
+          test: 'body',
+        },
+      },
+    };
+
+    normalizeHttpRequestBeforeHandler(handler, () => {});
+    expect(logger.meta.auth).toBe(handler.event.auth);
+    expect(logger.meta.queryStringParameters).toStrictEqual(
+      handler.event.queryStringParameters
+    );
+    expect(logger.meta.body).toStrictEqual(handler.event.body);
   });
 });

--- a/src/middlewares/normalizeHttpRequestMiddleware.js
+++ b/src/middlewares/normalizeHttpRequestMiddleware.js
@@ -55,18 +55,17 @@ export const normalizeHttpRequestBeforeHandler = (handler, next) => {
 
   const tags = {};
   switch (handler.event.version) {
-    case '1.0':
-      tags.path = handler.event.path;
-      tags.httpMethod = handler.event.httpMethod;
-      break;
-
-    default: {
+    case '2.0': {
       if (handler.event.requestContext && handler.event.requestContext.http) {
         tags.path = handler.event.requestContext.http.path;
         tags.httpMethod = handler.event.requestContext.http.method;
       }
       break;
     }
+    default:
+      tags.path = handler.event.path;
+      tags.httpMethod = handler.event.httpMethod;
+      break;
   }
 
   logger.addMeta({

--- a/src/middlewares/normalizeHttpRequestMiddleware.js
+++ b/src/middlewares/normalizeHttpRequestMiddleware.js
@@ -53,14 +53,27 @@ export const normalizeHttpRequestBeforeHandler = (handler, next) => {
   // eslint-disable-next-line no-param-reassign
   handler.event.auth = auth;
 
+  const tags = {};
+  switch (handler.event.version) {
+    case '1.0':
+      tags.path = handler.event.path;
+      tags.httpMethod = handler.event.httpMethod;
+      break;
+
+    default: {
+      if (handler.event.requestContext && handler.event.requestContext.http) {
+        tags.path = handler.event.requestContext.http.path;
+        tags.httpMethod = handler.event.requestContext.http.method;
+      }
+      break;
+    }
+  }
+
   logger.addMeta({
     requestId: handler.event.requestContext
       ? handler.event.requestContext.requestId
       : null,
-    tags: {
-      path: handler.event.path,
-      httpMethod: handler.event.httpMethod,
-    },
+    tags,
   });
 
   if (app.debug) {


### PR DESCRIPTION
## WHY
Currently API Gateway v2 does not log tags for http and method

## WHAT
Added support for API Gateway V2 to get from a different location as documented here: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html