### PR TITLE
Hotfix/v0.7.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lesgo",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Core framework for lesgo node.js serverless framework.",
   "main": "./src/index.js",
   "author": "Sufiyan Rahmat",

--- a/src/services/ElasticsearchService.js
+++ b/src/services/ElasticsearchService.js
@@ -45,7 +45,7 @@ class ElasticsearchService {
       body,
     };
 
-    this.client.search(param, (err, response) => {
+    return this.client.search(param, (err, response) => {
       if (err) return Promise.reject(err);
 
       this.result = response;
@@ -70,7 +70,7 @@ class ElasticsearchService {
       body: settings,
     };
 
-    this.client.indices.create(params, (err, response) => {
+    return this.client.indices.create(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
@@ -82,7 +82,7 @@ class ElasticsearchService {
       ...options,
     };
 
-    this.client.indices.delete(params, (err, response) => {
+    return this.client.indices.delete(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
@@ -91,7 +91,7 @@ class ElasticsearchService {
   existIndices(index, options = {}) {
     const params = { index, ...options };
 
-    this.client.indices.exists(params, (err, response) => {
+    return this.client.indices.exists(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response.body);
     });
@@ -100,7 +100,7 @@ class ElasticsearchService {
   putMapping(index, type, body) {
     const params = { index, type, body: { properties: body } };
 
-    this.client.indices.putMapping(params, (err, response) => {
+    return this.client.indices.putMapping(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
@@ -113,7 +113,7 @@ class ElasticsearchService {
       id,
     };
 
-    this.client.get(params, (err, response) => {
+    return this.client.get(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
@@ -128,14 +128,14 @@ class ElasticsearchService {
       refresh,
     };
 
-    this.client.index(params, (err, response) => {
+    return this.client.index(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
   }
 
   bulkIndex(bodies) {
-    this.client.bulk(
+    return this.client.bulk(
       { body: this.constructBulkIndex(bodies) },
       (err, response) => {
         if (err) return Promise.reject(err);
@@ -152,7 +152,7 @@ class ElasticsearchService {
       body,
     };
 
-    this.client.index(params, (err, response) => {
+    return this.client.index(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });
@@ -165,7 +165,7 @@ class ElasticsearchService {
       id,
     };
 
-    this.client.get(params, (err, response) => {
+    return this.client.get(params, (err, response) => {
       if (err) return Promise.reject(err);
       return Promise.resolve(response);
     });

--- a/src/services/ElasticsearchService.js
+++ b/src/services/ElasticsearchService.js
@@ -39,22 +39,17 @@ class ElasticsearchService {
   }
 
   search(body) {
-    return new Promise((resolve, reject) => {
-      const param = {
-        index: this.index,
-        type: this.type,
-        body,
-      };
-      this.client.search(param, (err, response) => {
-        /* istanbul ignore next */
-        if (err) {
-          reject(err);
-        }
+    const param = {
+      index: this.index,
+      type: this.type,
+      body,
+    };
 
-        this.result = response;
+    this.client.search(param, (err, response) => {
+      if (err) return Promise.reject(err);
 
-        resolve(response);
-      });
+      this.result = response;
+      return Promise.resolve(response);
     });
   }
 
@@ -75,11 +70,9 @@ class ElasticsearchService {
       body: settings,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.indices.create(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.indices.create(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
@@ -89,31 +82,27 @@ class ElasticsearchService {
       ...options,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.indices.delete(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.indices.delete(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
   existIndices(index, options = {}) {
     const params = { index, ...options };
-    return new Promise((resolve, reject) => {
-      this.client.indices.exists(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response.body);
-      });
+
+    this.client.indices.exists(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response.body);
     });
   }
 
   putMapping(index, type, body) {
     const params = { index, type, body: { properties: body } };
-    return new Promise((resolve, reject) => {
-      this.client.indices.putMapping(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+
+    this.client.indices.putMapping(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
@@ -124,11 +113,9 @@ class ElasticsearchService {
       id,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.get(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.get(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
@@ -141,24 +128,20 @@ class ElasticsearchService {
       refresh,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.index(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.index(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
   bulkIndex(bodies) {
-    return new Promise((resolve, reject) => {
-      this.client.bulk(
-        { body: this.constructBulkIndex(bodies) },
-        (err, response) => {
-          // eslint-disable-next-line no-unused-expressions
-          err ? /* istanbul ignore next */ reject(err) : resolve(response);
-        }
-      );
-    });
+    this.client.bulk(
+      { body: this.constructBulkIndex(bodies) },
+      (err, response) => {
+        if (err) return Promise.reject(err);
+        return Promise.resolve(response);
+      }
+    );
   }
 
   create(id, body) {
@@ -169,11 +152,9 @@ class ElasticsearchService {
       body,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.index(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.index(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 
@@ -184,11 +165,9 @@ class ElasticsearchService {
       id,
     };
 
-    return new Promise((resolve, reject) => {
-      this.client.get(params, (err, response) => {
-        // eslint-disable-next-line no-unused-expressions
-        err ? /* istanbul ignore next */ reject(err) : resolve(response);
-      });
+    this.client.get(params, (err, response) => {
+      if (err) return Promise.reject(err);
+      return Promise.resolve(response);
     });
   }
 

--- a/src/services/__tests__/LengthAwarePaginator.spec.js
+++ b/src/services/__tests__/LengthAwarePaginator.spec.js
@@ -32,6 +32,8 @@ describe('test LengthAwarePaginator instantiate', () => {
     expect(await paginator.lastItem()).toMatchObject(mockDataLastItem);
     expect(paginator.perPage()).toEqual(5);
     expect(await paginator.total()).toEqual(30);
+
+    expect(db.select).toHaveBeenCalled();
   });
   it('should not throw exception when instantiating with current page', async () => {
     const paginator = new LengthAwarePaginator(
@@ -51,6 +53,8 @@ describe('test LengthAwarePaginator instantiate', () => {
     expect(await paginator.lastItem()).toMatchObject(mockDataLastItem);
     expect(paginator.perPage()).toEqual(5);
     expect(await paginator.total()).toEqual(30);
+
+    expect(db.select).toHaveBeenCalled();
   });
   it('should default perPage to 10 when instantiating without perPage', async () => {
     const paginator = new LengthAwarePaginator(
@@ -66,6 +70,8 @@ describe('test LengthAwarePaginator instantiate', () => {
     expect(paginator.currentPage()).toEqual(1);
     expect(paginator.perPage()).toEqual(10);
     expect(await paginator.total()).toEqual(30);
+
+    expect(db.select).toHaveBeenCalled();
   });
   it('should throw exception if total is not a number', async () => {
     try {
@@ -116,6 +122,43 @@ describe('test LengthAwarePaginator instantiate', () => {
         { ...mockDataLastItem },
       ],
     });
+
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('should simply return an empty paginator object if total is explicitly zero', async () => {
+    const paginator = new LengthAwarePaginator(
+      db,
+      'SELECT * FROM tests',
+      {},
+      {
+        perPage: 5,
+        currentPage: 1,
+        total: 0,
+      }
+    );
+
+    expect(await paginator.count()).toEqual(0);
+    expect(await paginator.previousPage()).toEqual(false);
+    expect(paginator.currentPage()).toEqual(1);
+    expect(await paginator.nextPage()).toEqual(false);
+    expect(await paginator.firstItem()).toBe(undefined);
+    expect(await paginator.lastItem()).toBe(undefined);
+    expect(paginator.perPage()).toEqual(5);
+    expect(await paginator.total()).toEqual(0);
+
+    expect(await paginator.toObject()).toMatchObject({
+      count: 0,
+      previous_page: false,
+      current_page: 1,
+      next_page: false,
+      per_page: 5,
+      last_page: 0,
+      total: 0,
+      items: [],
+    });
+
+    expect(db.select).not.toHaveBeenCalled();
   });
 });
 
@@ -138,7 +181,7 @@ describe('test total() usage', () => {
 });
 
 describe('test lastPage() usage', () => {
-  it('should get the last page using supplied paramater as total data', async () => {
+  it('should get the last page using supplied parameter as total data', async () => {
     const paginator1 = new LengthAwarePaginator(
       db,
       'SELECT * FROM total_tests',

--- a/src/services/pagination/Paginator.js
+++ b/src/services/pagination/Paginator.js
@@ -217,11 +217,17 @@ export default class Paginator {
   }
 
   async executeQuery() {
-    this.response = await this.dbProp.select(
-      this.generatePaginationSqlSnippet(),
-      this.sqlParamsProp,
-      this.connection
-    );
+    const total = this.totalProp;
+    if (
+      (typeof total === 'number' && total > 0) ||
+      (typeof total !== 'number' && !total)
+    ) {
+      this.response = await this.dbProp.select(
+        this.generatePaginationSqlSnippet(),
+        this.sqlParamsProp,
+        this.connection
+      );
+    }
 
     this.hasNext = this.response.length > this.perPage();
     if (this.hasNext) {


### PR DESCRIPTION
Fix 2 issues

1. db.selectPaginate to return empty paginated response instead of executing query
2. Prevent MaxListenersExceededWarning: Possible EventEmitter memory leak detected when doing a full/partial re-index