### PR TITLE
feat: added `boolean` type validate field

### DIFF
--- a/src/utils/__tests__/validateFields.spec.js
+++ b/src/utils/__tests__/validateFields.spec.js
@@ -371,4 +371,53 @@ describe('test Utils/validateFields', () => {
       )
     );
   });
+
+  it.each`
+    input             | expectedOutcome
+    ${1}              | ${'valid'}
+    ${'1'}            | ${'invalid'}
+    ${0}              | ${'valid'}
+    ${'0'}            | ${'invalid'}
+    ${true}           | ${'valid'}
+    ${'true'}         | ${'valid'}
+    ${false}          | ${'valid'}
+    ${'false'}        | ${'valid'}
+    ${'string-input'} | ${'invalid'}
+    ${'2'}            | ${'invalid'}
+    ${3}              | ${'invalid'}
+  `(
+    'should be able to validate boolean input and throws an error if invalid',
+    async ({ input, expectedOutcome }) => {
+      const testInput = {
+        booleanCheck: input,
+      };
+      const inputFields = [
+        {
+          key: 'booleanCheck',
+          type: 'boolean',
+          required: true,
+        },
+      ];
+
+      try {
+        const validated = validateFields(testInput, inputFields);
+
+        if (expectedOutcome === 'valid') {
+          expect(validated).toEqual(testInput);
+        } else {
+          expect(validated).toThrow();
+        }
+      } catch (e) {
+        expect(e.name).toEqual('LesgoException');
+        expect(e.message).toEqual(
+          `Invalid type for 'booleanCheck', expecting 'boolean'`
+        );
+        expect(e.code).toEqual(`${FILE}::INVALID_TYPE_BOOLEANCHECK`);
+        expect(e.extra).toStrictEqual({
+          field: inputFields[0],
+          value: input,
+        });
+      }
+    }
+  );
 });

--- a/src/utils/validateFields.js
+++ b/src/utils/validateFields.js
@@ -19,6 +19,16 @@ const isValidJSON = json => {
   }
 };
 
+const isValidBoolean = input => {
+  if (typeof input === 'string') {
+    return input === 'true' || input === 'false';
+  }
+  if (typeof input === 'number') {
+    return input === 1 || input === 0;
+  }
+  return typeof input === 'boolean';
+};
+
 const validateFields = (params, validFields) => {
   const validated = {};
 
@@ -37,7 +47,7 @@ const validateFields = (params, validFields) => {
         }
       }
 
-      if (!params[key]) {
+      if (type !== 'boolean' && !params[key]) {
         if (typeof params[key] !== 'number') {
           throw new LesgoException(
             `Missing required '${key}'`,
@@ -66,6 +76,7 @@ const validateFields = (params, validFields) => {
 
     (isCollection ? params[key] || [] : [params[key]]).forEach(paramsItem => {
       if (
+        (type === 'boolean' && !isValidBoolean(paramsItem)) ||
         (type === 'string' &&
           typeof paramsItem !== 'undefined' &&
           typeof paramsItem !== 'string') ||


### PR DESCRIPTION
Currently, validation fields in the lesgo framework for a boolean check have no checking at all, this causes some of the microservices and overrides the files to fix the issue.

This commit fixes the nuance of manual overrides in our microservices to support `boolean` type validation.