### PR TITLE
Add generic type to query function

### DIFF
--- a/src/services/RDSAuroraMySQLProxyService/query.ts
+++ b/src/services/RDSAuroraMySQLProxyService/query.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions } from 'mysql2/promise';
+import { ConnectionOptions, QueryResult } from 'mysql2/promise';
 import { logger, validateFields } from '../../utils';
 import { RDSAuroraMySQLProxyClientOptions } from '../../types/aws';
 import { LesgoException } from '../../exceptions';
@@ -6,7 +6,7 @@ import getClient from './getMySQLProxyClient';
 
 const FILE = 'lesgo.services.RDSAuroraMySQLService.query';
 
-const query = async (
+const query = async <T>(
   sql: string,
   preparedValues?: any[],
   connOptions?: ConnectionOptions,
@@ -20,7 +20,10 @@ const query = async (
   const connection = await getClient(connOptions, clientOpts);
 
   try {
-    const resp = await connection.execute(input.sql, input.preparedValues);
+    const resp = await connection.execute<T & QueryResult>(
+      input.sql,
+      input.preparedValues
+    );
     logger.debug(`${FILE}::RECEIVED_RESPONSE`, {
       result: resp[0],
       sql,

--- a/src/services/RDSAuroraMySQLProxyService/query.ts
+++ b/src/services/RDSAuroraMySQLProxyService/query.ts
@@ -1,12 +1,4 @@
-import {
-  ConnectionOptions,
-  FieldPacket,
-  OkPacket,
-  ProcedureCallPacket,
-  QueryResult,
-  ResultSetHeader,
-  RowDataPacket,
-} from 'mysql2/promise';
+import { ConnectionOptions, FieldPacket, QueryResult } from 'mysql2/promise';
 import { logger, validateFields } from '../../utils';
 import { RDSAuroraMySQLProxyClientOptions } from '../../types/aws';
 import { LesgoException } from '../../exceptions';
@@ -14,17 +6,7 @@ import getClient from './getMySQLProxyClient';
 
 const FILE = 'lesgo.services.RDSAuroraMySQLService.query';
 
-type QueryResultType<T> = T extends ResultSetHeader
-  ? T
-  : T extends ResultSetHeader[]
-  ? T
-  : T extends RowDataPacket[]
-  ? T
-  : T extends RowDataPacket[][]
-  ? T
-  : T extends ProcedureCallPacket
-  ? T
-  : never;
+type QueryResultType<T> = T extends QueryResult ? T : never;
 
 type QueryReturn<T> = [T, FieldPacket[]];
 


### PR DESCRIPTION
# Enhance query function with improved type safety and flexibility

## Summary
This PR enhances the `query` function to provide improved type safety and flexibility when working with MySQL queries. The changes introduce a more precise type system that accurately represents different MySQL query result types while eliminating potential issues with type intersections.

## Changes
1. Introduced a `QueryResultType<T>` type alias to handle various MySQL result types more accurately.
2. Simplified the `QueryReturn<T>` type to remove unnecessary type intersections.
3. Updated the query function to use these new types, providing better type inference and safety.

## Benefits
- Stronger type checking for query results.
- Elimination of implicit type narrowing issues.
- More accurate representation of MySQL query result types.
- Improved developer experience with better type inference.

## Implementation Details

### New Type Definitions

```typescript
type QueryResultType<T> = T extends ResultSetHeader
  ? T
  : T extends ResultSetHeader[]
  ? T
  : T extends RowDataPacket[]
  ? T
  : T extends RowDataPacket[][]
  ? T
  : T extends ProcedureCallPacket
  ? T
  : never;

type QueryReturn<T> = [T, FieldPacket[]];
```

### Updated Query Function Signature

```typescript
const query = async <T = QueryResult>(
  sql: string,
  preparedValues?: any[],
  connOptions?: ConnectionOptions,
  clientOpts?: RDSAuroraMySQLProxyClientOptions
): Promise<QueryReturn<T>> => {};
```

## Usage Examples

### SELECT Query

```typescript
interface User {
  id: number;
  name: string;
  email: string;
}

async function getUsers() {
  const [users, fields] = await query<User[]>('SELECT id, name, email FROM users');
  
  console.log(users[0].name); // Correctly typed as string
}
```

### INSERT Query

```typescript
async function insertUser(name: string, email: string) {
  const [result, fields] = await query<ResultSetHeader>(
    'INSERT INTO users (name, email) VALUES (?, ?)',
    [name, email]
  );
  
  console.log(`Inserted user with ID: ${result.insertId}`);
}
```
