### PR TITLE
Add typings for query & validatedFields

### DIFF
--- a/src/services/RDSAuroraMySQLProxyService/getMySQLProxyClient.ts
+++ b/src/services/RDSAuroraMySQLProxyService/getMySQLProxyClient.ts
@@ -29,9 +29,8 @@ const getMySQLProxyClient = async (
 
   const region = options.region || rdsConfig.aurora.mysql.region;
   const singletonConn = options.singletonConn || 'default';
-  const dbCredentialsSecretId =
-    options.dbCredentialsSecretId ||
-    rdsConfig.aurora.mysql.proxy.dbCredentialsSecretId;
+  const dbCredentialsSecretId = (options.dbCredentialsSecretId ||
+    rdsConfig.aurora.mysql.proxy.dbCredentialsSecretId) as string;
   const databaseName =
     options.databaseName || rdsConfig.aurora.mysql.databaseName;
 

--- a/src/utils/__tests__/validateFields.test.ts
+++ b/src/utils/__tests__/validateFields.test.ts
@@ -1,5 +1,5 @@
 import LesgoException from '../../exceptions/LesgoException';
-import validateFields from '../validateFields';
+import validateFields, { Field } from '../validateFields';
 
 describe('validateFields', () => {
   const validFields = [
@@ -17,7 +17,7 @@ describe('validateFields', () => {
       enumValues: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
     },
     { key: 'someFunction', type: 'function', required: false },
-  ];
+  ] satisfies Field[];
 
   it('should validate fields and return validated object', () => {
     const params = {

--- a/src/utils/db/mysql/proxy/query.ts
+++ b/src/utils/db/mysql/proxy/query.ts
@@ -2,13 +2,13 @@ import { ConnectionOptions } from 'mysql2/promise';
 import queryService from '../../../../services/RDSAuroraMySQLProxyService/query';
 import { RDSAuroraMySQLProxyClientOptions } from '../../../../types/aws';
 
-const query = async (
+const query = async <T>(
   sql: string,
   preparedValues?: any[],
   connOptions?: ConnectionOptions,
   clientOpts?: RDSAuroraMySQLProxyClientOptions
 ) => {
-  const [res] = await queryService(
+  const [res] = await queryService<T>(
     sql,
     preparedValues,
     connOptions,


### PR DESCRIPTION
# Enhance Type Safety and Flexibility in Utility Functions

## Summary
This PR improves type safety and flexibility in two key utility functions: `validateFields` and `query`. It introduces more precise type systems that accurately represent different data structures and query result types while eliminating potential issues with type intersections.

## Changes Overview

### validateFields Function
1. Updated `Params` type to `Record<PropertyKey, unknown>` for increased flexibility.
2. Improved type annotations in the `validateFields` function.
3. Enhanced readability of the validation logic.

### query Function
1. Introduced a `QueryResultType<T>` type alias to handle various MySQL result types more accurately.
2. Simplified the `QueryReturn<T>` type to remove unnecessary type intersections.
3. Updated the query function to use these new types, providing better type inference and safety.

## Detailed Changes

### validateFields.ts

1. Type Definitions:
   - Updated `Params` type:
     ```typescript
     export type Params = Record<PropertyKey, unknown>;
     ```
   - This change allows for string, number, and symbol keys, increasing flexibility.

2. Function Signature:
   - Updated to use the new `Params` type:
     ```typescript
     const validateFields = <T extends Params>(params: T, validFields: Field[]) => {
     ```

3. Validation Logic:
   - Improved readability of collection handling:
     ```typescript
     const paramsItems = isCollection
       ? (params[key] as unknown[]) || []
       : [params[key]];
     ```
   - This change makes the code more readable without altering its functionality.

4. Type Assertions:
   - Updated the assignment of validated fields:
     ```typescript
     (validated as T)[key as keyof T] = params[key] as T[keyof T];
     ```
   - This maintains type safety while allowing for flexible key types.

### query.ts

1. New Type Definitions:
   ```typescript
   type QueryResultType<T> = T extends ResultSetHeader
     ? T
     : T extends ResultSetHeader[]
     ? T
     : T extends RowDataPacket[]
     ? T
     : T extends RowDataPacket[][]
     ? T
     : T extends ProcedureCallPacket
     ? T
     : never;

   type QueryReturn<T> = [T, FieldPacket[]];
   ```

2. Updated Query Function Signature:
   ```typescript
   const query = async <T = QueryResult>(
     sql: string,
     preparedValues?: any[],
     connOptions?: ConnectionOptions,
     clientOpts?: RDSAuroraMySQLProxyClientOptions
   ): Promise<QueryReturn<T>> => {};
   ```

## Benefits
- Stronger type checking for both object validation and query results.
- Elimination of implicit type narrowing issues in MySQL queries.
- More accurate representation of various data structures and MySQL query result types.
- Improved developer experience with better type inference across utilities.
- Enhanced code readability in the `validateFields` function.

## Impact
- Improved type inference and safety when using both `validateFields` and `query` functions.
- Better handling of various input types, including objects with numeric or symbol keys in `validateFields`.
- More precise typing for different MySQL query result types in the `query` function.