### PR TITLE
Hotfix/v2.1.10

### DIFF
--- a/dist/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.d.ts
+++ b/dist/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.d.ts
@@ -1,2 +1,5 @@
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 declare const disconnectMySQLProxyClient: () => Promise<void>;
 export default disconnectMySQLProxyClient;

--- a/dist/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.js
+++ b/dist/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.js
@@ -32,29 +32,30 @@ var __awaiter =
     });
   };
 import { logger } from '../../utils';
-import { singleton } from '../RDSAuroraMySQLProxyService/getMySQLProxyClient';
 const FILE =
   'lesgo.services.RDSAuroraMySQLProxyService.disconnectMySQLProxyClient';
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 const disconnectMySQLProxyClient = () =>
   __awaiter(void 0, void 0, void 0, function* () {
-    const singletonConns = Object.keys(singleton);
-    if (singletonConns.length === 0) {
-      logger.debug(`${FILE}::NO_CONNECTIONS_TO_DISCONNECT`);
-      return;
-    }
-    logger.debug(`${FILE}::PREPARING_TO_DISCONNECT`, {
-      singletonConns,
-    });
-    singletonConns.forEach(singletonConn =>
-      __awaiter(void 0, void 0, void 0, function* () {
-        try {
-          yield singleton[singletonConn].end();
-          delete singleton[singletonConn];
-          logger.debug(`${FILE}::COMPLETED`, { singletonConn });
-        } catch (err) {
-          logger.error(`${FILE}::ERROR`, { singletonConn, err });
-        }
-      })
-    );
+    logger.warn(`${FILE}::DEPRECATED_FUNCTION_DO_NOT_END_POOL_CONNECTION`);
+    // const singletonConns = Object.keys(singleton);
+    // if (singletonConns.length === 0) {
+    //   logger.debug(`${FILE}::NO_CONNECTIONS_TO_DISCONNECT`);
+    //   return;
+    // }
+    // logger.debug(`${FILE}::PREPARING_TO_DISCONNECT`, {
+    //   singletonConns,
+    // });
+    // singletonConns.forEach(async singletonConn => {
+    //   try {
+    //     await singleton[singletonConn].end();
+    //     delete singleton[singletonConn];
+    //     logger.debug(`${FILE}::COMPLETED`, { singletonConn });
+    //   } catch (err) {
+    //     logger.error(`${FILE}::ERROR`, { singletonConn, err });
+    //   }
+    // });
   });
 export default disconnectMySQLProxyClient;

--- a/dist/utils/db/mysql/proxy/disconnectDb.d.ts
+++ b/dist/utils/db/mysql/proxy/disconnectDb.d.ts
@@ -1,2 +1,5 @@
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 declare const disconnectDb: () => Promise<void>;
 export default disconnectDb;

--- a/dist/utils/db/mysql/proxy/disconnectDb.js
+++ b/dist/utils/db/mysql/proxy/disconnectDb.js
@@ -1,4 +1,7 @@
 import { disconnectMySQLProxyClient } from '../../../../services/RDSAuroraMySQLProxyService';
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 const disconnectDb = () => {
   return disconnectMySQLProxyClient();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lesgo",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Core framework for lesgo node.js serverless framework.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/services/ElastiCacheRedisService/__tests__/deleteRedisCache.test.ts
+++ b/src/services/ElastiCacheRedisService/__tests__/deleteRedisCache.test.ts
@@ -31,11 +31,15 @@ describe('deleteRedisCache', () => {
     expect(mockClient.del).toHaveBeenCalledWith(key);
 
     expect(logger.debug).toHaveBeenCalledWith(
-      'lesgo.services.ElastiCacheRedis.deleteRedisCache::RECEIVED_RESPONSE',
-      { resp: 1, keys: input }
+      'lesgo.services.ElastiCacheRedis.deleteRedisCache::CACHE_KEY_DELETED',
+      { key: 'testKey', resp: 1 }
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'lesgo.services.ElastiCacheRedis.deleteRedisCache::ALL_KEYS_DELETED',
+      { keys: input }
     );
 
-    expect(result).toEqual(1);
+    expect(result).toBeUndefined();
   });
 
   it('should throw an exception when client.del fails', async () => {

--- a/src/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.ts
+++ b/src/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.ts
@@ -1,29 +1,31 @@
 import { logger } from '../../utils';
-import { singleton } from '../RDSAuroraMySQLProxyService/getMySQLProxyClient';
 
 const FILE =
   'lesgo.services.RDSAuroraMySQLProxyService.disconnectMySQLProxyClient';
 
+// @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
 const disconnectMySQLProxyClient = async () => {
-  const singletonConns = Object.keys(singleton);
-  if (singletonConns.length === 0) {
-    logger.debug(`${FILE}::NO_CONNECTIONS_TO_DISCONNECT`);
-    return;
-  }
+  logger.warn(`${FILE}::DEPRECATED_FUNCTION_DO_NOT_END_POOL_CONNECTION`);
 
-  logger.debug(`${FILE}::PREPARING_TO_DISCONNECT`, {
-    singletonConns,
-  });
+  // const singletonConns = Object.keys(singleton);
+  // if (singletonConns.length === 0) {
+  //   logger.debug(`${FILE}::NO_CONNECTIONS_TO_DISCONNECT`);
+  //   return;
+  // }
 
-  singletonConns.forEach(async singletonConn => {
-    try {
-      await singleton[singletonConn].end();
-      delete singleton[singletonConn];
-      logger.debug(`${FILE}::COMPLETED`, { singletonConn });
-    } catch (err) {
-      logger.error(`${FILE}::ERROR`, { singletonConn, err });
-    }
-  });
+  // logger.debug(`${FILE}::PREPARING_TO_DISCONNECT`, {
+  //   singletonConns,
+  // });
+
+  // singletonConns.forEach(async singletonConn => {
+  //   try {
+  //     await singleton[singletonConn].end();
+  //     delete singleton[singletonConn];
+  //     logger.debug(`${FILE}::COMPLETED`, { singletonConn });
+  //   } catch (err) {
+  //     logger.error(`${FILE}::ERROR`, { singletonConn, err });
+  //   }
+  // });
 };
 
 export default disconnectMySQLProxyClient;

--- a/src/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.ts
+++ b/src/services/RDSAuroraMySQLProxyService/disconnectMySQLProxyClient.ts
@@ -3,7 +3,9 @@ import { logger } from '../../utils';
 const FILE =
   'lesgo.services.RDSAuroraMySQLProxyService.disconnectMySQLProxyClient';
 
-// @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 const disconnectMySQLProxyClient = async () => {
   logger.warn(`${FILE}::DEPRECATED_FUNCTION_DO_NOT_END_POOL_CONNECTION`);
 

--- a/src/utils/db/mysql/proxy/disconnectDb.ts
+++ b/src/utils/db/mysql/proxy/disconnectDb.ts
@@ -1,5 +1,8 @@
 import { disconnectMySQLProxyClient } from '../../../../services/RDSAuroraMySQLProxyService';
 
+/**
+ * @deprecated Disconnect db is no longer to be used due to the use of ConnectionPool
+ */
 const disconnectDb = () => {
   return disconnectMySQLProxyClient();
 };


### PR DESCRIPTION
Deprecated `disconnectDb` function as it should not be used with db connection pool to prevent prematurely ending the connection pool and disallowing other concurrent executions from re-using the connection pool.